### PR TITLE
Inspection Details fixes

### DIFF
--- a/RubberduckWeb/RubberduckWeb/Controllers/InspectionsController.cs
+++ b/RubberduckWeb/RubberduckWeb/Controllers/InspectionsController.cs
@@ -19,7 +19,7 @@ namespace RubberduckWeb.Controllers
             }
 
             var ignoreModuleExample = @"Option Explicit
-'@IgnoreModule; inspections will ignore this module";
+'@IgnoreModule: inspections will ignore this module";
 
             return View(new InspectionsModel(RubberduckAssets.Inspections.Values.Where(e => !e.IsHidden), ignoreModuleExample));
         }

--- a/RubberduckWeb/RubberduckWeb/Models/InspectionInfo.cs
+++ b/RubberduckWeb/RubberduckWeb/Models/InspectionInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
@@ -6,6 +6,15 @@ using RubberduckWeb.VBA;
 
 namespace RubberduckWeb.Models
 {
+    internal static class XElementExtensions
+    {
+        /// <summary>
+        /// Gets an attribute by name, case-insensitive. Matches the beginning of the name, to match both e.g. "hasresults" and "hasresult"
+        /// </summary>
+        public static XAttribute GetAttribute(this XElement e, string name) 
+            => e.Attributes().SingleOrDefault(a => a.Name.LocalName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase));
+    }
+
     public class InspectionsModel
     {
         public InspectionsModel(IEnumerable<InspectionInfo> inspections, string ignoreModuleExampleCode)
@@ -19,6 +28,32 @@ namespace RubberduckWeb.Models
         public string IgnoreModuleAnnotationExample { get; }
     }
 
+    public class InspectionCodeExample
+    {
+        public InspectionCodeExample(bool? hasResult, IEnumerable<InspectionCodeExampleModule> modules)
+        {
+            HasResult = hasResult.HasValue && hasResult.Value || !hasResult.HasValue; // null == true
+            Modules = modules;
+        }
+
+        public bool HasResult { get; }
+        public IEnumerable<InspectionCodeExampleModule> Modules { get; }
+    }
+
+    public class InspectionCodeExampleModule
+    {
+        public InspectionCodeExampleModule(string formattedContent, string name = null, string moduleType = null)
+        {
+            Name = name;
+            ModuleType = moduleType;
+            FormattedContent = formattedContent;
+        }
+
+        public string Name { get; }
+        public string ModuleType { get; }
+        public string FormattedContent { get; }
+    }
+
     public class InspectionInfo
     {
         public InspectionInfo(string name, XElement node, bool isPreRelease = false)
@@ -26,46 +61,29 @@ namespace RubberduckWeb.Models
             IsPreRelease = isPreRelease;
             InspectionName = name.Replace("Inspection", string.Empty).Trim();
             Summary = node.Element("summary")?.Value.Trim();
-            IsHidden = node.Element("summary")?.Attribute("hidden")?.Value == "true";
+            IsHidden = node.Element("summary")?.GetAttribute("hidden")?.Value.Equals("true", StringComparison.InvariantCultureIgnoreCase) ?? false;
             Reasoning = node.Element("why")?.Value.Trim();
-            References = node.Elements("references").Select(e => e.Attribute("name")?.Value).ToArray();
-            HostApp = node.Element("hostapp")?.Attribute("name")?.Value.Trim();
+            References = node.Elements("reference").Select(e => e.GetAttribute("name")?.Value).ToArray();
+            HostApp = node.Element("hostapp")?.GetAttribute("name")?.Value.Trim();
             Remarks = node.Element("remarks")?.Value;
 
-            var examples = ParseExamples(node);
-            ResultExamples = examples.Results;
-            NoResultExamples = examples.NoResults;
+            Examples = ParseExamples(node);
         }
 
-        private (string[] Results, string[] NoResults) ParseExamples(XElement node)
+        private InspectionCodeExample[] ParseExamples(XElement node)
         {
             var formatter = new FormattedCodeBlockBuilder();
-
-            var resultExamples = new List<string>();
-            var noResultExamples = new List<string>();
-
-            var examples = node.Elements("example")
-                .GroupBy(e => e.Attribute("hasResult")?.Value ?? "implicit")
-                .Select(g => new {HasExample = g.Key, Examples = g.Select(e => formatter.Format(e.Value))})
-                .ToDictionary(e => e.HasExample, e => e.Examples.ToArray());
-
-            if (examples.TryGetValue("implicit", out var implicitExamples))
-            {
-                resultExamples.Add(implicitExamples[0]);
-                noResultExamples.AddRange(implicitExamples.Skip(1));
-            }
-
-            if (examples.TryGetValue("true", out var explicitResultExamples))
-            {
-                resultExamples.AddRange(explicitResultExamples);
-            }
-
-            if (examples.TryGetValue("false", out var explicitNoResultExamples))
-            {
-                noResultExamples.AddRange(explicitNoResultExamples);
-            }
-
-            return (resultExamples.ToArray(), noResultExamples.ToArray());
+            return node.Elements("example")
+                .Select(e => new InspectionCodeExample(
+                    e.GetAttribute("hasresult")?.Value.Equals("true", StringComparison.InvariantCultureIgnoreCase),
+                    e.Elements("module").Select(m => 
+                        new InspectionCodeExampleModule(
+                            formatter.Format(m.Nodes().OfType<XCData>().Single().Value), 
+                            m.GetAttribute("name")?.Value,
+                            m.GetAttribute("type")?.Value))
+                        .Concat(e.Nodes().OfType<XCData>().Select(x =>
+                            new InspectionCodeExampleModule(formatter.Format(x.Value))).Take(1))
+                )).ToArray();
         }
 
         public bool IsPreRelease { get; }
@@ -76,7 +94,6 @@ namespace RubberduckWeb.Models
         public string HostApp { get; }
         public string Reasoning { get; }
         public string Remarks { get; }
-        public string[] ResultExamples { get; private set; }
-        public string[] NoResultExamples { get; private set; }
+        public InspectionCodeExample[] Examples { get; }
     }
 }

--- a/RubberduckWeb/RubberduckWeb/Views/Inspections/Details.cshtml
+++ b/RubberduckWeb/RubberduckWeb/Views/Inspections/Details.cshtml
@@ -38,39 +38,53 @@
                 }
                 </dd>
                 }
-                @if (Model.ResultExamples.Any())
+                @if (Model.Examples.Any(e => e.HasResult))
                 {
                 <dt>The following code example(s) would trigger this inspection:</dt>
                 <dd>
-                @foreach (var example in Model.ResultExamples)
+                @foreach (var example in Model.Examples.Where(e => e.HasResult))
                 {
-                <p>
-                    <div class="vbe-mock-debugger">
-                        <div class="code-area">
-                            <div class="code">
-                                <div class="block">@Html.Raw(example)</div>
+                    foreach (var module in example.Modules)
+                    {
+                        if (!string.IsNullOrEmpty(module.Name))
+                        {
+                            <div>@module.Name</div>
+                        }
+                        <p>
+                        <div class="vbe-mock-debugger">
+                            <div class="code-area">
+                                <div class="code">
+                                    <div class="block">@Html.Raw(module.FormattedContent)</div>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </p>
+                        </p>
+                    }
                 }
                 </dd>
                 }
-                @if (Model.NoResultExamples.Any())
+                @if (Model.Examples.Any(e => !e.HasResult))
                 {
                 <dt>The following code example(s) would <strong>not</strong> trigger this inspection:</dt>
                 <dd>
-                @foreach (var example in Model.NoResultExamples)
+                @foreach (var example in Model.Examples.Where(e => !e.HasResult))
                 {
-                <p>
-                    <div class="vbe-mock-debugger">
-                        <div class="code-area">
-                            <div class="code">
-                                <div class="block">@Html.Raw(example)</div>
+                    foreach (var module in example.Modules)
+                    {
+                        if (!string.IsNullOrEmpty(module.Name))
+                        {
+                            <div>@module.Name</div>
+                        }
+                        <p>
+                            <div class="vbe-mock-debugger">
+                                <div class="code-area">
+                                    <div class="code">
+                                        <div class="block">@Html.Raw(module.FormattedContent)</div>
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                    </div>
-                </p>
+                        </p>
+                    }
                 }
                 </dd>
                 }


### PR DESCRIPTION
These changes make the the inspection xml-docs much more flexible.

 - `hasresult` attributes (all attributes actually) are now matched case-insensitively, and using `StartsWith`, so `hasresults` and `hasResults` would both match.
 - Introducing support for a `module` node (which itself supports `name` and `type` attributes, respectively for the module name and component type e.g. "Class Module" or "UserForm" - content isn't validated at this point).

Inspection examples that need multiple modules can now do this:

```xml
<example hasresult="true">
<module name="Module1" type="Standard">
<![CDATA[
Option Explicit
...
]]>
</module>
<module name="Class1" type="Class">
<![CDATA[
Option Explicit
...
]]>
</module>
</example>
```

Otherwise, the `CDATA` code block can also remain directly under the `<example>` tag. Although theoretically supported, inspection xml-doc examples should either all use a `<module>` tag, or none of them should.

No need for a `<module>` tag if the module type is irrelevant or if there's only one module, however when the example is only applicable in a specific module type, consider including a `<module>` tag with a e.g. `type="Class"` attribute, even if there's only one single module involved.

Now, does anyone knows enough CSS to make the module name & type look pretty?